### PR TITLE
Accept Dependabot as Claude Code workflow trigger

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -65,6 +65,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: dependabot
           # Git credential errors ("fatal: not in a git directory") appear because
           # there's no local checkout. These are harmless and ignored by the action.
           # Enabling commit signing avoids the error but enables Claude to commit
@@ -95,6 +96,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: dependabot
           # Git credential errors ("fatal: not in a git directory") appear because
           # there's no local checkout. These are harmless and ignored by the action.
           # Enabling commit signing avoids the error but enables Claude to commit


### PR DESCRIPTION
The ClauDependabot workflow stopped functioning when `claude-code-action@v1` automatically updated to v1.0.30 on 2026-01-16. That release introduced bot-actor validation (anthropics/claude-code-action#826) as a security measure to prevent rapid, bot-triggered workflow loops that could exhaust API rate limits and result in account bans.

The action now rejects bot actors unless explicitly allowed via the `allowed_bots` parameter. Without this configuration, Dependabot PRs trigger workflows that immediately fail with: "Workflow initiated by non-human actor: dependabot (type: Bot)".

This change explicitly permits Dependabot to trigger Claude Code reviews by adding `allowed_bots: dependabot` to both minor and major review steps. The @v1 tag tracks the latest v1.x release, which provides convenience but exposes workflows to behavioral changes in patch releases.

After merging, re-run go-digitaltwin/go-digitaltwin#12 to verify the workflow succeeds with Dependabot as the triggering actor.

See: anthropics/claude-code-action#826
See: anthropics/claude-code-action#387