### PR TITLE
Provide repository context to gh CLI in Claude workflows

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Review minor
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
         uses: anthropics/claude-code-action@v1
+        env:
+          GH_REPO: ${{ github.repository }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: dependabot
@@ -94,6 +96,8 @@ jobs:
       - name: Review major
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
         uses: anthropics/claude-code-action@v1
+        env:
+          GH_REPO: ${{ github.repository }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: dependabot


### PR DESCRIPTION
The ClauDependabot workflow runs without a local checkout, which prevents gh CLI from inferring repository context from the current directory. When Claude executes commands like `gh pr diff` or `gh pr view`, gh needs to know which repository to query.

Setting the `GH_REPO` environment variable provides this context explicitly. With this configuration, Claude can use short gh commands (e.g., `gh pr diff 12`) instead of requiring full URLs or `--repo` flags in every invocation.

This change applies to both the "Review minor" and "Review major" steps where Claude analyzes Dependabot PRs. The workflow already provides PR URLs in the prompt, and Claude can trivially extract the PR number to use with gh commands.

Related to #5 (Dependabot configuration).